### PR TITLE
Add theme selector with persistence

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import {
   Fieldset,
   Panel,
   Slider,
+  Select,
   TextField,
   Toolbar,
   Window,
@@ -15,11 +16,18 @@ import {
 import RNet from './rnet-pi/rnet';
 import Zone from './rnet-pi/zone';
 import ExtraZoneParam from './rnet-pi/extraZoneParam';
+// @ts-ignore
+import themes from 'react95/dist/themes';
 
 const ROOT_CONTROLLER = 0;
 const MAX_ZONES = 6;
 
-function App() {
+interface AppProps {
+  themeName: string;
+  setThemeName: (name: string) => void;
+}
+
+function App({themeName, setThemeName}: AppProps) {
   const [url, setURL] = useState(localStorage.getItem('lastUrl') || 'ws://localhost:8080');
   const [rnetState, setRNetState] = useState('Ready');
   const [, setUpdate] = useState(0);
@@ -95,6 +103,10 @@ function App() {
 
   const sources =
     rnetRef.current?.getSources()?.map((_, i) => ({value: i, label: String(i)})) ?? [];
+  const themeOptions = Object.keys(themes).map(name => ({
+    value: name,
+    label: (themes as any)[name].name || name,
+  }));
 
   return (
     <div id="root">
@@ -115,6 +127,13 @@ function App() {
           >
             New Zone
           </Button>
+          <Select
+            options={themeOptions}
+            value={themeName}
+            width={150}
+            onChange={((e: any, option: any) => setThemeName(option.value as string)) as any}
+            style={{marginLeft: 4}}
+          />
         </Toolbar>
         <Divider />
         <WindowContent>

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,6 +5,8 @@ import {styleReset} from 'react95';
 // @ts-ignore
 import original from 'react95/dist/themes/original';
 // @ts-ignore
+import themes from 'react95/dist/themes';
+// @ts-ignore
 import ms_sans_serif from 'react95/dist/fonts/ms_sans_serif.woff2';
 // @ts-ignore
 import ms_sans_serif_bold from 'react95/dist/fonts/ms_sans_serif_bold.woff2';
@@ -29,14 +31,31 @@ const GlobalStyles = createGlobalStyle`
   ${styleReset}
 `;
 
+function Root() {
+  const [themeName, setThemeName] = React.useState(
+    localStorage.getItem('theme') || 'original',
+  );
+  // @ts-ignore
+  const theme = (themes as any)[themeName] || original;
+
+  const handleChange = React.useCallback((name: string) => {
+    setThemeName(name);
+    localStorage.setItem('theme', name);
+  }, []);
+
+  return (
+    <ThemeProvider theme={theme}>
+      <App themeName={themeName} setThemeName={handleChange} />
+    </ThemeProvider>
+  );
+}
+
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 root.render(
   <React.StrictMode>
     <div>
       <GlobalStyles />
-      <ThemeProvider theme={original}>
-        <App />
-      </ThemeProvider>
+      <Root />
     </div>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- add dynamic theme selection stored in local storage
- create Root wrapper component to handle theme state
- render `Select` menu in toolbar for choosing React95 theme

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b0bdc72fc83288c0f2ebe327f34b9